### PR TITLE
pytomo3d requires an old version of obspy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ Wenjie: If you are new to python, [anaconda](https://www.continuum.io/downloads)
 
 2. install obspy using anaconda.
   ```
-  conda install -c obspy obspy
+  conda install -c obspy obspy=1.0.3
   ```
   Recently, obspy group has a big upgrade for obspy, which boost the version number from 0.10.x to 1.0.0. A lot of kernel functions has changed its module path. The recent version of pytomo3d also now no longer supports older version of obspy. Please upgrade your obspy version to at least 1.0.0.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "seismology", "tomography", "adjoint", "signal", "inversion", "window"
     ],
     install_requires=[
-        "numpy", "obspy>=1.0.0", "flake8>=3.0", "pytest", "nose",
+        "numpy", "obspy==1.0.3", "flake8>=3.0", "pytest", "nose",
         "future>=0.14.1", "pyflex", "pyadjoint", "geographiclib"
     ],
     extras_require={


### PR DESCRIPTION
This is a temporary fix so that Carl's group can use your tools.  In the long run you'll either need to stop maintaining separate forks of Lion's packages, or else be prepared for repeated compatibility issues of this type.